### PR TITLE
Linux compatability and rounding numbers of cols and rows up instead of down

### DIFF
--- a/lib/tileup.rb
+++ b/lib/tileup.rb
@@ -101,8 +101,8 @@ module TileUp
       # find image width and height
       # then find out how many tiles we'll get out of
       # the image, then use that for the xy offset in crop.
-      num_columns = image.columns/tile_width
-      num_rows = image.rows/tile_height
+      num_columns = (image.columns/tile_width.to_f).ceil
+      num_rows = (image.rows/tile_height.to_f).ceil
       x,y,column,row = 0,0,0,0
       crops = []
 


### PR DESCRIPTION
I had a couple of problems using this tool on Linux (Debian):
1. Case sensitivity caused error when requiring the rmagick lib
2. Dir lib did not work for creating directory structure - switched to Fileutils.mkdir_p which I think is more straightforward anyway.

I did not test these on a platform other than my own.

Also, fixed typing issue when passing tile-height and tile-width param.

Finally,  I was having an issue with some parts of my images not being included in the tiles.  And that fix is included in the second commit.

Thanks for making this tool - it was very useful to me, and I believe I will be using it very much in the future.
